### PR TITLE
Ignore omitempty in json tags when interpreting fieldnames

### DIFF
--- a/options.go
+++ b/options.go
@@ -123,6 +123,8 @@ func getFieldJSONName(field string, t reflect.Type) string {
 	if json, ok := f.Tag.Lookup("json"); ok {
 		field = json
 	}
+	//Strip omitempty if it exists
+	field = strings.Replace(field, ",omitempty", "", -1)
 	return field
 }
 


### PR DESCRIPTION
I was running into an issue when using the `omitempty` directive in json field tags to suppress fields on my struct that should be omitted when empty.

This isn't elegant, but it did fix the problem for me!